### PR TITLE
修改设置按钮位置以及样式

### DIFF
--- a/src/bilibili.com/components/FullHeaderButton.ts
+++ b/src/bilibili.com/components/FullHeaderButton.ts
@@ -20,28 +20,47 @@ export default class FullHeaderButton {
       return;
     }
     const container = obtainHTMLElementByID({
-      tag: 'li',
+      tag: 'div',
       id: FullHeaderButton.id,
       onDidCreate: (el) => {
-        el.classList.add('right-entry-item');
-        parent.prepend(...[parent.firstChild, el].filter(isNonNull));
+        document.body.appendChild(el)
       },
     });
     render(
       html`
   <button
     type="button"
-    class="right-entry__outside" 
+    style="
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            z-index: 99999; /* 确保在最上层 */
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 5px;
+            padding: 10px 16px;
+            background-color: white; /* 背景色，根据需要调整（如跟随夜间模式） */
+            color: #333;             /* 文字颜色 */
+            border: 1px solid #e0e0e0;
+            border-radius: 50px;     /* 圆角胶囊样式 */
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15); /* 悬浮阴影 */
+            cursor: pointer;
+            transition: transform 0.2s;
+          "
+          /* 添加简单的鼠标悬停效果（可选，通过 onmouseenter/leave 模拟 CSS hover） */
+          @mouseenter=${(e) => e.currentTarget.style.transform = 'scale(1.05)'}
+          @mouseleave=${(e) => e.currentTarget.style.transform = 'scale(1)'}
     @click=${(e: Event) => {
       e.preventDefault();
       e.stopPropagation();
       this.settings.open();
     }}
   >
-    <svg viewBox="2 2 20 20" class="right-entry-icon" style="height: 20px; fill: currentColor;">
+    <svg viewBox="2 2 20 20" style="height: 20px; width: 20px; fill: currentColor;">
       <path fill-rule="evenodd" clip-rule="evenodd" d=${mdiEyeOffOutline}>
     </svg>
-    <span class="right-entry-text">屏蔽</span>
+    <span style="font-size: 14px; font-weight: 500;">屏蔽</span>
   </button>
 `,
       container


### PR DESCRIPTION
close #7 
**修改思路**
将原本的按钮从b站原生的栏位独立，成为一个悬浮按钮，美观又实用
位置暂定于页面右下角
css以及部分逻辑修改使用了ai并且保留了ai的注释以及痕迹

**如此做的好处**
1. 在用户使用了其他修改样式的脚本后，此脚本的设置按钮也可正常展示
2. 更美观

**问题**
ide检测到有两个参数未指定类型，我对ts不是很熟悉，不做修改，等待审查
